### PR TITLE
docs: release v4.21.0, update connector docs

### DIFF
--- a/docs/connectors/on-prem-databases/postgresql.md
+++ b/docs/connectors/on-prem-databases/postgresql.md
@@ -39,7 +39,9 @@ When using PostgreSQL as the target database or obtaining incremental data via t
 
 ## Supported Operations
 
-**INSERT**, **UPDATE**, **DELETE**
+**DML operations**: **INSERT**, **UPDATE**, **DELETE**
+
+**DDL operations**: Add columns, rename columns, change column attributes, and drop columns
 
 :::tip
 
@@ -50,7 +52,8 @@ When using PostgreSQL as the target database or obtaining incremental data via t
 
 ## Limitations
 
-- When PostgreSQL is used as a source database, capturing its DDL (like adding fields) is not supported, nor is specifying a time for incremental data capture.
+- When PostgreSQL is used as a source, the physical log plugin does not support specifying an incremental start time. When you use pgoutput, wal2json, or decoderbufs, to start incremental sync from a specified time, set **WAL Retention Hours** in the source node advanced features to a value greater than 0 and make sure the target time is within the retention window.
+- To collect DDL events from a PostgreSQL source, use a logical replication plugin such as pgoutput, wal2json, or decoderbufs, and turn on **Enable DDL Trigger** in the source node advanced features. This feature creates the `public._tapdata_ddl_audit` audit table, an event trigger, and a trigger function in the source database by default. The sync account must have permission to create event triggers, which usually requires superuser privileges.
 - PostgreSQL does not support storing `\0` in string types; TapData will automatically filter it to avoid exceptions.
 - To capture incremental events for partitioned parent tables, PostgreSQL version 13 or above must be used, and the pgoutput plugin must be selected.
 - The Walminer plugin currently only supports connecting and merging shared mining.
@@ -149,6 +152,12 @@ When using PostgreSQL as the target database or obtaining incremental data via t
 
    - [Decoderbufs](https://github.com/debezium/postgres-decoderbufs): Suitable for PostgreSQL 9.6 and above, uses Google Protocol Buffers to parse WAL logs but requires more complex configuration.
    - [Walminer](https://gitee.com/movead/XLogMiner/tree/master/): Does not rely on logical replication, doesn't require setting `wal_level` to `logical`, or adjusting replication slot configuration, but requires superuser permissions. In a **replication architecture**, we recommend using the **Walminer** plugin to read incremental changes to ensure data integrity during failover.
+
+   :::tip
+
+   To collect DDL events from a PostgreSQL source, select the pgoutput, wal2json, or decoderbufs plugin and make sure the sync account has permission to create event triggers. TapData writes DDL events to the `public._tapdata_ddl_audit` audit table through an event trigger, then collects changes from the audit table through a logical replication slot. If the account does not have sufficient permissions or you do not need DDL event collection, turn off **Enable DDL Trigger** in the task source node advanced features.
+
+   :::
 
    Next, we will demonstrate the installation process using **Wal2json** as an example.
 
@@ -462,6 +471,8 @@ When configuring data synchronization/conversion tasks, you can use PostgreSQL a
   * **Hash Sharding**: When enabled, all table data will be split into multiple shards based on hash values during the full synchronization phase, allowing concurrent data reading. This significantly improves reading performance but also increases the database load. The maximum number of shards can be manually set after enabling this option.
   * **Partition Table CDC Root Table**: Supported only in PostgreSQL 13 and above, and when selecting the pgoutput log plugin. When enabled, only CDC events for root tables will be detected; when disabled, only CDC events for child tables will be detected.
   * **Max Queue Size**: Specifies the queue size for reading incremental data in PostgreSQL. The default value is **8000**. If the downstream synchronization is slow or individual table records are too large, consider lowering this value.
+  * **Enable DDL Trigger**: Enabled by default. TapData creates the `public._tapdata_ddl_audit` audit table, a DDL event trigger, and a trigger function in the source database by default. It writes source DDL events to the audit table and collects them through a logical replication slot. Supported events include adding columns, renaming columns, changing column attributes, and dropping columns. If the sync account does not have sufficient permissions or DDL event collection is not required, turn this off.
+  * **WAL Retention Hours**: The default is **0**, in hours. This setting retains CDC checkpoints and the WAL advancement window for logical replication. When set to 0, historical checkpoints are not retained. When set to a value greater than 0, TapData can start incremental sync from a specified time within the retention window. A longer retention period might increase WAL usage in the source database.
   * **Split Update Unique Key**: Enabled by default. When updating unique key fields, this splits UPDATE into DELETE + INSERT events to improve target compatibility. Disable this if you need to preserve original UPDATE events (e.g., for auditing or change tracking).
 * As a Target Node
   * **Ignore NotNull**: Default is off, meaning NOT NULL constraints will be ignored when creating tables in the target database.

--- a/docs/connectors/on-prem-databases/postgresql.md
+++ b/docs/connectors/on-prem-databases/postgresql.md
@@ -122,7 +122,11 @@ When using PostgreSQL as the target database or obtaining incremental data via t
       * **schema_name**: Schema name.
       * **username**: Username.
 
-3. <span id="prerequisites">Execute the following</span> command format to modify the replica identity to FULL (using the entire row as the identifier), which determines the fields recorded in the log when data undergoes UPDATE/DELETE.
+3. If you need to collect DDL events from the PostgreSQL source, make sure the sync account can create event triggers.
+
+   PostgreSQL requires superuser privileges to create event triggers. For managed PostgreSQL services, confirm that event triggers are supported and grant the equivalent administrator role. If you cannot grant these privileges or do not need DDL event collection, turn off **Enable DDL Trigger** in the source node advanced features before starting the task.
+
+4. <span id="prerequisites">Execute the following</span> command format to modify the replica identity to FULL (using the entire row as the identifier), which determines the fields recorded in the log when data undergoes UPDATE/DELETE.
 
    :::tip
 
@@ -137,7 +141,7 @@ When using PostgreSQL as the target database or obtaining incremental data via t
    * **schema_name**: Schema name.
    * **table_name**: Table name.
 
-4. Log in to the server hosting PostgreSQL, and choose the decoder plugin to install based on business needs and version:
+5. Log in to the server hosting PostgreSQL, and choose the decoder plugin to install based on business needs and version:
 
    - [Wal2json](https://github.com/eulerto/wal2json/blob/master/README.md) (Recommended): Suitable for PostgreSQL 9.4 and above, converts WAL logs to JSON format, simple to use, but requires source tables to have primary keys; otherwise, delete operations cannot be synchronized.
    - [Pgoutput](https://www.postgresql.org/docs/15/sql-createsubscription.html): An internal logical replication protocol introduced in PostgreSQL 10, no additional installation needed. For tables with primary keys and `replica identity` set to `default`, the `before` in update events will be empty, which can be solved by setting `replica identity full`. Additionally, if you do not have database-level **CREATE** permissions, you need to run the following commands to create the required PUBLICATION:
@@ -228,7 +232,7 @@ When using PostgreSQL as the target database or obtaining incremental data via t
       service postgresql-12.service restart
       ```
 
-5. (Optional) Test the log plugin.
+6. (Optional) Test the log plugin.
 
    1. Connect to the postgres database, switch to the database to be synchronized, and create a test table.
 
@@ -471,7 +475,7 @@ When configuring data synchronization/conversion tasks, you can use PostgreSQL a
   * **Hash Sharding**: When enabled, all table data will be split into multiple shards based on hash values during the full synchronization phase, allowing concurrent data reading. This significantly improves reading performance but also increases the database load. The maximum number of shards can be manually set after enabling this option.
   * **Partition Table CDC Root Table**: Supported only in PostgreSQL 13 and above, and when selecting the pgoutput log plugin. When enabled, only CDC events for root tables will be detected; when disabled, only CDC events for child tables will be detected.
   * **Max Queue Size**: Specifies the queue size for reading incremental data in PostgreSQL. The default value is **8000**. If the downstream synchronization is slow or individual table records are too large, consider lowering this value.
-  * **Enable DDL Trigger**: Enabled by default. TapData creates the `public._tapdata_ddl_audit` audit table, a DDL event trigger, and a trigger function in the source database by default. It writes source DDL events to the audit table and collects them through a logical replication slot. Supported events include adding columns, renaming columns, changing column attributes, and dropping columns. If the sync account does not have sufficient permissions or DDL event collection is not required, turn this off.
+  * **Enable DDL Trigger**: Enabled by default. Before starting a task with this option enabled, make sure the sync account can create PostgreSQL event triggers. TapData creates the `public._tapdata_ddl_audit` audit table, a DDL event trigger, and a trigger function in the source database by default. It writes source DDL events to the audit table and collects them through a logical replication slot. Supported events include adding columns, renaming columns, changing column attributes, and dropping columns. If the sync account does not have sufficient permissions or DDL event collection is not required, turn this off.
   * **WAL Retention Hours**: The default is **0**, in hours. This setting retains CDC checkpoints and the WAL advancement window for logical replication. When set to 0, historical checkpoints are not retained. When set to a value greater than 0, TapData can start incremental sync from a specified time within the retention window. A longer retention period might increase WAL usage in the source database.
   * **Split Update Unique Key**: Enabled by default. When updating unique key fields, this splits UPDATE into DELETE + INSERT events to improve target compatibility. Disable this if you need to preserve original UPDATE events (e.g., for auditing or change tracking).
 * As a Target Node

--- a/docs/connectors/supported-data-sources.md
+++ b/docs/connectors/supported-data-sources.md
@@ -183,7 +183,7 @@ import TabItem from '@theme/TabItem';
     <td>PostgreSQL</td>
     <td>✅</td>
     <td>✅</td>
-    <td>➖</td>
+    <td>✅</td>
     <td>✅</td>
     <td>✅</td>
     <td>9.4～16</td>

--- a/docs/release-notes-on-prem.md
+++ b/docs/release-notes-on-prem.md
@@ -14,6 +14,37 @@ import TabItem from '@theme/TabItem';
 <TabItem value="Version 4.x" default>
 ```
 
+## 4.21.0
+
+### New Features
+
+- [PostgreSQL](connectors/on-prem-databases/postgresql.md) sources now support DDL event collection. TapData can capture schema changes such as adding columns, renaming columns, changing column attributes, and dropping columns, and work with target-side DDL apply to synchronize schema changes.
+
+### Enhancements
+
+- Refactored and upgraded [MCP Server](experimental/mcp/quick-start.md) to improve protocol adaptation and tool extensibility.
+- Improved frontend multilingual message adaptation by supporting unified `i18nMessage` handling.
+- Improved task monitoring metric display. Related charts can now be controlled by the task CPU and memory metric collection switches.
+- Improved email template variables in [Notification and Alert Settings](system-admin/other-settings/notification.md), so notification content can reference the task description.
+- Improved task canvas node-centering logic for a smoother canvas layout experience.
+
+### Bug Fixes
+
+- Fixed insufficient script execution isolation for JS processing nodes in specific scenarios, improving custom script runtime security.
+- Fixed insufficient protection when displaying or storing some sensitive information, improving credential security.
+- Fixed an issue where, when shared mining was unavailable and a merge task fell back to regular CDC, the source connection might report an error after entering the incremental phase.
+- Fixed issues where task metrics, heartbeat status, or incremental lag alerts could become abnormal after a full sync completed or a task restarted.
+- Fixed an issue where duplicate path validation might not work as expected when adding or editing an API, and API publishing could fail in specific scenarios.
+- Fixed missing password rule prompts when creating roles.
+- Fixed issues in the CI/CD task import and publish flow where duplicate projects might be created, primary-secondary tasks might fail to run, or adding an FDM table might unexpectedly trigger a full sync.
+- Fixed an issue where tasks could remain in **Starting** for an extended time after a single-node deployment restarted.
+- Fixed an issue in master-child merge tasks where the target did not delete fields as expected after fields were removed from embedded documents in child tables.
+- Fixed an issue where task retry alerts were still displayed after recovery.
+- Fixed an issue where reverse synchronization from PostgreSQL to Sybase could fail because of foreign key constraint validation.
+- Fixed an issue where polling requests continuously refreshed user active time, so sessions could remain active even when users performed no actions.
+- Fixed an issue where sub-accounts could not view engine tags.
+- Fixed an issue where task startup could fail after DDL event collection was enabled.
+
 ## 4.20.0
 
 ### New Features

--- a/docs/system-admin/other-settings/notification.md
+++ b/docs/system-admin/other-settings/notification.md
@@ -51,7 +51,7 @@ You can also click **Custom Email Template** in the top-right corner of the page
 
 ![Customize Email Template](../../images/alter_email_templates.png)
 
-The subject and body support variables such as task name, task description, error time, and error log. You can quickly insert them by clicking the variable names at the bottom of the page.
+The subject and body support insertable variables such as `{taskName}` (task name), task description, `{errorTime}` (error time), and `{errorLog}` (error log). You can quickly insert them by clicking the variable names at the bottom of the page.
 
 ## Webhook Alerts
 

--- a/docs/system-admin/other-settings/notification.md
+++ b/docs/system-admin/other-settings/notification.md
@@ -51,7 +51,7 @@ You can also click **Custom Email Template** in the top-right corner of the page
 
 ![Customize Email Template](../../images/alter_email_templates.png)
 
-The subject and body support the following insertable variables: `{taskName}` (task name), `{errorTime}` (error time), and `{errorLog}` (error log). You can quickly insert them by clicking the variable names at the bottom of the page.
+The subject and body support variables such as task name, task description, error time, and error log. You can quickly insert them by clicking the variable names at the bottom of the page.
 
 ## Webhook Alerts
 


### PR DESCRIPTION
- Add complete 4.21.0 on-prem release notes covering new PostgreSQL DDL collection support, enhancements, and bug fixes
- Update PostgreSQL connector documentation to document DDL event collection, new advanced config options, and revised limitations
- Revise notification settings documentation to reflect updated email template variables including task description
- Mark PostgreSQL as supporting DDL events in the supported data sources list